### PR TITLE
Fix r libs

### DIFF
--- a/rstudio_on_nesi/__init__.py
+++ b/rstudio_on_nesi/__init__.py
@@ -43,7 +43,7 @@ def setup_rstudio():
             "{port}",
             "{base_url}rstudio",
         ],
-        "timeout": 15,
+        "timeout": 120,
         "environment": {"PASSWORD": rstudio_password, "SIFPATH": sif_path},
         "absolute_url": False,
         "launcher_entry": {

--- a/rstudio_on_nesi/singularity_runscript.bash
+++ b/rstudio_on_nesi/singularity_runscript.bash
@@ -85,12 +85,8 @@ http {
 }
 EOF
 
-# find R_LIBS_USER from R itself and append R_LIBS if exists
-R_LIBS_USER=$(Rscript -e "cat(Sys.getenv('R_LIBS_USER'))")
-
-if [[ -n ${R_LIBS:+1} ]]; then
-    R_LIBS_USER="$R_LIBS_USER:$R_LIBS"
-fi
+# use R to find the path to libraries, including R_LIBS_USER
+R_LIBS_USER=$(Rscript -e "cat(unique(c(Sys.getenv('R_LIBS_USER'), .libPaths())), sep=':')")
 
 RSESSION_CONFIG_FILE="/var/lib/rstudio-server/rsession.conf"
 echo "r-libs-user=$R_LIBS_USER" > "$RSESSION_CONFIG_FILE"


### PR DESCRIPTION
Hi,

This should fix the issue with properly exposing the path to R packages when using a NeSI module in the prelude.bash.
The issue is that:

- RStudio only propagate R_LIBS_USER to the interpreter running within RStudio(it doesn't care about R_LIBS or R_LIB_SITE).
- Therefore, one need to collect all paths that should be exposed by a NeSI R module and put then in the R_LIBS_USER environment variable before starting RStudio.
- However, different NeSI R modules set different variables.. some set R_LIBS (R-GEO/4.0.1), some set R_LIBS_SITE (R-bundle-Bioconductor/3.13-gimkl-2020a-R-4.1.0), some nothing (R/3.6.2-gimkl-2020a).

Therefore this fix uses the R interpreter itself to pull the path that it has access to. Note that `.libPaths()` won't return the user lib path (R_LIBS_USER) if they don't exist, hence the additional `Sys.getenv('R_LIBS_USER')`.